### PR TITLE
Use native ROMAN config files in fastsam_node and roman_map_node

### DIFF
--- a/roman_ros2/cfg/default_mapper.yaml
+++ b/roman_ros2/cfg/default_mapper.yaml
@@ -1,0 +1,13 @@
+# ROMAN (non-ROS) MapperParams
+min_iou: 0.25
+min_sightings: 2
+max_t_no_sightings: 0.4
+merge_objects_iou_3d: 0.25
+merge_objects_iou_2d: 0.8
+mask_downsample_factor: 8
+min_max_extent: 0.25
+plane_prune_params: [3.0, 3.0, 0.5]
+segment_graveyard_time: 15.0
+segment_graveyard_dist: 10.0
+iou_voxel_size: 0.2
+segment_voxel_size: 0.05

--- a/roman_ros2/launch/roman_map_example.launch.py
+++ b/roman_ros2/launch/roman_map_example.launch.py
@@ -8,9 +8,13 @@ from ament_index_python.packages import get_package_share_directory
 
 robot = LaunchConfiguration('robot')
 camera = LaunchConfiguration('camera')
+config_path = LaunchConfiguration('config_path')
 
 robot_launch_arg = DeclareLaunchArgument('robot')
 camera_launch_arg = DeclareLaunchArgument('camera')
+config_path_launch_arg = DeclareLaunchArgument('config_path',
+    default_value=os.path.join(
+    get_package_share_directory('roman_ros2'), 'cfg', 'default_mapper.yaml'))
 
 
 topic_remappings = [
@@ -28,6 +32,8 @@ frame_params = {
     'odom_base_frame_id': [robot, '/base'],
 }
 
+config_path_param = {'config_path': config_path}
+
 def generate_launch_description():
     return LaunchDescription([
         Node(
@@ -37,7 +43,7 @@ def generate_launch_description():
             name='roman_map_node',
             output='screen',
             emulate_tty=True,
-            parameters=[os.path.join(get_package_share_directory('roman_ros2'), 'cfg', 'default_roman_map.yaml'), frame_params],
+            parameters=[os.path.join(get_package_share_directory('roman_ros2'), 'cfg', 'default_roman_map.yaml'), frame_params, config_path_param],
             remappings=topic_remappings + tf_remappings
         )
 ])

--- a/roman_ros2/roman_ros2/fastsam_node.py
+++ b/roman_ros2/roman_ros2/fastsam_node.py
@@ -77,7 +77,11 @@ class FastSAMNode(Node):
         color_params = CameraParams.from_msg(color_info_msg)
 
         # fastsam wrapper
-        fastsam_params = FastSAMParams.from_yaml(config_path)
+        if config_path != "":
+            fastsam_params = FastSAMParams.from_yaml(config_path)
+        else:
+            fastsam_params = FastSAMParams()
+            
         self.fastsam = FastSAMWrapper.from_params(fastsam_params, self.depth_params)
 
         self.setup_ros()

--- a/roman_ros2/roman_ros2/roman_map_node.py
+++ b/roman_ros2/roman_ros2/roman_map_node.py
@@ -51,10 +51,7 @@ class RomanMapNode(Node):
             namespace='',
             parameters=[
                 ("robot_id", 0),
-                ("min_iou", 0.25),
-                ("min_sightings", 2),
-                ("max_t_no_sightings", 0.25),
-                ("mask_downsample_factor", 8),
+                ("config_path", ""),
                 ("visualize", False),
                 ("output_roman_map", ""),
                 ("map_frame_id", "map"),
@@ -71,10 +68,6 @@ class RomanMapNode(Node):
         )
 
         self.robot_id = self.get_parameter("robot_id").value
-        min_iou = self.get_parameter("min_iou").value
-        min_sightings = self.get_parameter("min_sightings").value
-        max_t_no_sightings = self.get_parameter("max_t_no_sightings").value
-        mask_downsample_factor = self.get_parameter("mask_downsample_factor").value
         self.visualize = self.get_parameter("visualize").value
         self.output_file = self.get_parameter("output_roman_map").value
         self.object_ref = self.get_parameter("object_ref").value
@@ -82,6 +75,7 @@ class RomanMapNode(Node):
         T_camera_flu = np.array(T_camera_flu).reshape(4, 4)
         self.publish_active_segments = self.get_parameter("publish_active_segments").value
         self.nickname = self.get_parameter("nickname").value
+        config_path = self.get_parameter("config_path").value
 
         if self.visualize:
             self.map_frame_id = self.get_parameter("map_frame_id").value
@@ -108,12 +102,10 @@ class RomanMapNode(Node):
         color_params = CameraParams.from_msg(color_info_msg)
         self.log_and_send_status("RomanMapNode received for color camera info messages...", status=NodeInfoMsg.STARTUP)
 
-        mapper_params = MapperParams(
-            min_iou=min_iou,
-            min_sightings=min_sightings,
-            max_t_no_sightings=max_t_no_sightings,
-            mask_downsample_factor=mask_downsample_factor,
-        )
+        if config_path != "":
+            mapper_params = MapperParams.from_yaml(config_path)
+        else:
+            mapper_params = MapperParams()
         self.mapper = Mapper(
            mapper_params,
            camera_params=color_params
@@ -230,8 +222,9 @@ class RomanMapNode(Node):
             elif self.viz_rotate_img == "180":
                 img = cv.rotate(img, cv.ROTATE_180)
         
-        img_msg = self.bridge.cv2_to_imgmsg(img, encoding="bgr8")
-        self.annotated_img_pub.publish(img_msg)
+        annotated_img_msg = self.bridge.cv2_to_imgmsg(img, encoding="bgr8")
+        annotated_img_msg.header = img_msg.header
+        self.annotated_img_pub.publish(annotated_img_msg)
         
     def log_and_send_status(self, note, status=NodeInfoMsg.NOMINAL):
         """


### PR DESCRIPTION
Fix so that no config file is required, but if one is provided, the config file can be in the same format as core ROMAN params.